### PR TITLE
remove contao-community-alliance/composer-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "contao/core-bundle": "^3.5.1 || ~4.1",
         "contao-community-alliance/composer-plugin": "~2.4 || ~3.0",
         "robloach/component-installer": "*",
-        "contao-community-alliance/composer-installer": "*",
         "components/bootstrap": ">=3.3,<4-dev",
         "heimrichhannot/font-awesome" : ">=4.4,<5-dev",
         "heimrichhannot/elegant-icons" : ">=1.0,<2-dev",


### PR DESCRIPTION
The `contao-community-alliance/composer-installer` is obsolete and incompatible with Contao 4. However, very old versions of this package _can_ in fact be installed in Contao 4, since older versions did not require a Contao version. See also https://community.contao.org/de/showthread.php?68584-Exception-occured-Could-not-find-constants-php